### PR TITLE
Fix link to french intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## French
 
- - [Introduction](fr/intro) ;
+ - [Introduction](fr/intro.md) ;
 
 
 ## What is Cozy?


### PR DESCRIPTION
With the markdown extension in the link, it will work in the published "github pages" site, but also when browsing in github sources.